### PR TITLE
Allow uv_build < 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.8.2,<0.9.0"]
+requires = ["uv_build>=0.8.2,<0.10.0"]
 build-backend = "uv_build"
 
 [tool.pyright]


### PR DESCRIPTION
Related to https://github.com/NixOS/nixpkgs/pull/449568.

Reference: https://github.com/astral-sh/uv/releases/tag/0.9.0
