### PR TITLE
use `exact:` for remote syntax

### DIFF
--- a/src/jj_pre_push/cli.py
+++ b/src/jj_pre_push/cli.py
@@ -63,7 +63,7 @@ def check(ctx: typer.Context):
                 # bookmark's target that isn't already on the remote, then diffs from
                 # its parent. Really we should consider the possibility of a local merge
                 # derived from multiple remote heads; so:
-                on_remote = f"(::remote_bookmarks(remote={u.remote}))"
+                on_remote = f"(::remote_bookmarks(remote=exact:{u.remote}))"
                 our_remote_heads = f"heads(::{u.new_commit} & {on_remote})"
                 from_refs = [c.commit_id for c in jj.get_changes(our_remote_heads)]
 


### PR DESCRIPTION
Using `exact:` to prefix the remote to remove the deprecation warning:

```
Warning: In revset expression
 --> 1:51
  |
1 | heads(::419dfda53300 & (::remote_bookmarks(remote=origin)))
  |                                                   ^----^
  |
  = Default pattern syntax will be changed to `glob:` / `exact:` (depending on whether it looks like a glob) in a future release; use `substring:` prefix or set ui.revsets-use-glob-by-default=true to suppress this warning
```