### PR TITLE
Update `jj git push` parsing for new bookmark syntax

### DIFF
--- a/src/jj_pre_push/bookmark_updates.py
+++ b/src/jj_pre_push/bookmark_updates.py
@@ -30,18 +30,27 @@ class BookmarkUpdate:
 # TODO: Consider parsing more rigidly?
 # If the wording changes in the future, it's better to fail than to parse incorrectly!
 _remote_pattern = re.compile(r"^Changes to push to (.+?):")
-_bookmark_update_patterns: dict[BookmarkUpdateType, re.Pattern] = {
-    "move_forward": re.compile(
-        r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[move forward from (?P<old_commit>\w+) to (?P<new_commit>\w+)\]"
-    ),
-    "move_backward": re.compile(
-        r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[move backward from (?P<old_commit>\w+) to (?P<new_commit>\w+)\]"
-    ),
-    "move_sideways": re.compile(
-        r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[move sideways from (?P<old_commit>\w+) to (?P<new_commit>\w+)\]"
-    ),
-    "add": re.compile(r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[add to (?P<new_commit>\w+)\]"),
-    "delete": re.compile(r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[delete from (?P<old_commit>\w+)\]"),
+_bookmark_update_patterns: dict[BookmarkUpdateType, list[re.Pattern]] = {
+    "move_forward": [
+        re.compile(r"Move forward bookmark (?P<bookmark>\S+) from (?P<old_commit>\w+) to (?P<new_commit>\w+)"),
+        re.compile(r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[move forward from (?P<old_commit>\w+) to (?P<new_commit>\w+)\]")
+    ],
+    "move_backward": [
+        re.compile(r"Move backward bookmark (?P<bookmark>\S+) from (?P<old_commit>\w+) to (?P<new_commit>\w+)"),
+        re.compile(r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[move backward from (?P<old_commit>\w+) to (?P<new_commit>\w+)\]")
+    ],
+    "move_sideways": [
+        re.compile(r"Move sideways bookmark (?P<bookmark>\S+) from (?P<old_commit>\w+) to (?P<new_commit>\w+)"),
+        re.compile(r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[move sideways from (?P<old_commit>\w+) to (?P<new_commit>\w+)\]")
+    ],
+    "add": [
+        re.compile(r"Add bookmark (?P<bookmark>\S+) to (?P<new_commit>\w+)"),
+        re.compile(r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[add to (?P<new_commit>\w+)\]")
+    ],
+    "delete": [
+        re.compile(r"Delete bookmark (?P<bookmark>\S+) from (?P<old_commit>\w+)"),
+        re.compile(r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[delete from (?P<old_commit>\w+)\]")
+    ],
 }
 
 
@@ -53,13 +62,14 @@ def parse_git_push_dry_run(output: str) -> set[BookmarkUpdate]:
     for line in output.splitlines():
         if match := _remote_pattern.search(line):
             remote = match.group(1)
-        for update_type, pattern in _bookmark_update_patterns.items():
-            if match := pattern.search(line):
-                if remote is None:
-                    raise ValueError("Unexpected line ordering in jj git push --dry-run")
-                updates.add(
-                    BookmarkUpdate(**match.groupdict(), remote=remote, update_type=update_type)
-                )
+        for update_type, patterns in _bookmark_update_patterns.items():
+            for pattern in patterns:
+                if match := pattern.search(line):
+                    if remote is None:
+                        raise ValueError("Unexpected line ordering in jj git push --dry-run")
+                    updates.add(
+                        BookmarkUpdate(**match.groupdict(), remote=remote, update_type=update_type)
+                    )
     return updates
 
 

--- a/src/jj_pre_push/bookmark_updates.py
+++ b/src/jj_pre_push/bookmark_updates.py
@@ -32,16 +32,16 @@ class BookmarkUpdate:
 _remote_pattern = re.compile(r"^Changes to push to (.+?):")
 _bookmark_update_patterns: dict[BookmarkUpdateType, re.Pattern] = {
     "move_forward": re.compile(
-        r"Move forward bookmark (?P<bookmark>\S+) from (?P<old_commit>\w+) to (?P<new_commit>\w+)"
+        r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[move forward from (?P<old_commit>\w+) to (?P<new_commit>\w+)\]"
     ),
     "move_backward": re.compile(
-        r"Move backward bookmark (?P<bookmark>\S+) from (?P<old_commit>\w+) to (?P<new_commit>\w+)"
+        r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[move backward from (?P<old_commit>\w+) to (?P<new_commit>\w+)\]"
     ),
     "move_sideways": re.compile(
-        r"Move sideways bookmark (?P<bookmark>\S+) from (?P<old_commit>\w+) to (?P<new_commit>\w+)"
+        r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[move sideways from (?P<old_commit>\w+) to (?P<new_commit>\w+)\]"
     ),
-    "add": re.compile(r"Add bookmark (?P<bookmark>\S+) to (?P<new_commit>\w+)"),
-    "delete": re.compile(r"Delete bookmark (?P<bookmark>\S+) from (?P<old_commit>\w+)"),
+    "add": re.compile(r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[add to (?P<new_commit>\w+)\]"),
+    "delete": re.compile(r"^\s*bookmark:\s+(?P<bookmark>\S+)\s+\[delete from (?P<old_commit>\w+)\]"),
 }
 
 

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -11,7 +11,19 @@ Changes to push to origin:
   bookmark: deleted [delete from 9c712e75a982]
 Dry-run requested, not pushing.
 """
-    assert parse_git_push_dry_run(output) == {
+
+    # Also test the output format used up through JJ v0.44.0.
+    legacy_output = """\
+Changes to push to origin:
+  Move forward bookmark main from d964e724c76e to a81d749233ff
+  Add bookmark painstaking to 591f7e9aae85
+  Move sideways bookmark sideways from 9c712e75a982 to 23f89ce4b31b
+  Move backward bookmark backward from d964e724c76e to 561998a40ada
+  Delete bookmark deleted from 9c712e75a982
+Dry-run requested, not pushing.
+"""
+
+    expected = {
         BookmarkUpdate(
             "origin", "main", "move_forward", "d964e724c76e", "a81d749233ff"
         ),
@@ -24,3 +36,6 @@ Dry-run requested, not pushing.
         ),
         BookmarkUpdate("origin", "deleted", "delete", "9c712e75a982"),
     }
+
+    for output in [output, legacy_output]:
+        assert parse_git_push_dry_run(output) == expected

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -4,11 +4,11 @@ from jj_pre_push.bookmark_updates import BookmarkUpdate, parse_git_push_dry_run
 def test_parse_git_push_dry_run():
     output = """\
 Changes to push to origin:
-  Move forward bookmark main from d964e724c76e to a81d749233ff
-  Add bookmark painstaking to 591f7e9aae85
-  Move sideways bookmark sideways from 9c712e75a982 to 23f89ce4b31b
-  Move backward bookmark backward from d964e724c76e to 561998a40ada
-  Delete bookmark deleted from 9c712e75a982
+  bookmark: main [move forward from d964e724c76e to a81d749233ff]
+  bookmark: painstaking [add to 591f7e9aae85]
+  bookmark: sideways [move sideways from 9c712e75a982 to 23f89ce4b31b]
+  bookmark: backward [move backward from d964e724c76e to 561998a40ada]
+  bookmark: deleted [delete from 9c712e75a982]
 Dry-run requested, not pushing.
 """
     assert parse_git_push_dry_run(output) == {


### PR DESCRIPTION
Update the regular expressions in `bookmark_updates.py` to match the new format introduced in `jj` (e.g., `bookmark: name [action from old to new]`) as well as the legacy format. Corresponding tests in `test_parse.py` have also been updated to test both formats.

This handles the output changes from `jj` PR https://github.com/jj-vcs/jj/pull/9279 which was merged after release v0.40.0 and will likely be included in v0.41.0.

Assisted-by: Antigravity with Gemini