### PR TITLE
feat: added support for hk

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,13 @@ desc = "jj push selected bookmark(s)"
 
 Note that these depend upon the `jj push` alias defined in the previous section.
 
-## Usage with hk
+## Usage with other checkers/hook managers
 
-You can use jj-pre-push with [hk](https://github.com/jdx/hk) by specifying the name of the
-checker program on the command-line as `jj-pre-push --checker hk ...`, or set the
-environment variable `JJ_PRE_PUSH_CHECKER=hk`.
+jj-pre-push has rudimentary support for checkers other than pre-commit - to use a
+different checker, specify its name on the command line with `jj-pre-push --checker
+CHECKER ...` or set the environment variable `JJ_PRE_PUSH_CHECKER`. Supported checkers:
 
-## Usage with prek
-
-You can use jj-pre-push with any checker that has a CLI compatible with pre-commit, for
-example [prek](https://github.com/j178/prek): specify the name of the checker program on
-the command-line as `jj-pre-push --checker prek ...`, or set the environment variable
-`JJ_PRE_PUSH_CHECKER=prek`.
+- [`pre-commit`](https://pre-commit.com/)
+- [`prek`](https://github.com/j178/prek), or any other checker with a
+  pre-commit-compatible CLI
+- [`hk`](https://github.com/jdx/hk)

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ desc = "jj push selected bookmark(s)"
 
 Note that these depend upon the `jj push` alias defined in the previous section.
 
+## Usage with hk
+
+You can use jj-pre-push with [hk](https://github.com/jdx/hk) by specifying the name of the
+checker program on the command-line as `jj-pre-push --checker hk ...`, or set the
+environment variable `JJ_PRE_PUSH_CHECKER=hk`.
+
 ## Usage with prek
 
 You can use jj-pre-push with any checker that has a CLI compatible with pre-commit, for

--- a/src/jj_pre_push/cli.py
+++ b/src/jj_pre_push/cli.py
@@ -47,6 +47,14 @@ def callback(
     )
 
 
+def command(checker: str):
+    match checker:
+        case "hk":
+            return ["hk", "run", "pre-push"]
+        case _:
+            return [checker, "run", "--hook-stage", "pre-push"]
+
+
 @app.command(context_settings={"allow_extra_args": True, "ignore_unknown_options": True})
 def check(ctx: typer.Context):
     settings = cast(Settings, ctx.obj)
@@ -110,9 +118,7 @@ def check(ctx: typer.Context):
                 # we use whatever version the user has installed on their PATH - seems
                 # like the least surprising thing to do.
                 ref_opts = ["--from-ref", from_ref, "--to-ref", u.new_commit]
-                result = subprocess.run(
-                    [settings.checker, "run", "--hook-stage", "pre-push", *ref_opts]
-                )
+                result = subprocess.run([*command(settings.checker), *ref_opts])
                 if result.returncode != 0:
                     success = False
                     change = jj.current_change()

--- a/src/jj_pre_push/cli.py
+++ b/src/jj_pre_push/cli.py
@@ -47,7 +47,7 @@ def callback(
     )
 
 
-def command(checker: str):
+def checker_command(checker: str):
     match checker:
         case "hk":
             return ["hk", "run", "pre-push"]
@@ -118,7 +118,7 @@ def check(ctx: typer.Context):
                 # we use whatever version the user has installed on their PATH - seems
                 # like the least surprising thing to do.
                 ref_opts = ["--from-ref", from_ref, "--to-ref", u.new_commit]
-                result = subprocess.run([*command(settings.checker), *ref_opts])
+                result = subprocess.run([*checker_command(settings.checker), *ref_opts])
                 if result.returncode != 0:
                     success = False
                     change = jj.current_change()

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,15 +1,13 @@
-import pytest
-
-from jj_pre_push.cli import command
+from jj_pre_push.cli import checker_command
 
 
 def test_command_pre_commit():
-    assert command("pre-commit") == ["pre-commit", "run", "--hook-stage", "pre-push"]
+    assert checker_command("pre-commit") == ["pre-commit", "run", "--hook-stage", "pre-push"]
 
 
 def test_command_prek():
-    assert command("prek") == ["prek", "run", "--hook-stage", "pre-push"]
+    assert checker_command("prek") == ["prek", "run", "--hook-stage", "pre-push"]
 
 
 def test_command_hk():
-    assert command("hk") == ["hk", "run", "pre-push"]
+    assert checker_command("hk") == ["hk", "run", "pre-push"]

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,0 +1,15 @@
+import pytest
+
+from jj_pre_push.cli import command
+
+
+def test_command_pre_commit():
+    assert command("pre-commit") == ["pre-commit", "run", "--hook-stage", "pre-push"]
+
+
+def test_command_prek():
+    assert command("prek") == ["prek", "run", "--hook-stage", "pre-push"]
+
+
+def test_command_hk():
+    assert command("hk") == ["hk", "run", "pre-push"]


### PR DESCRIPTION
I added support for `hk` which has a slightly different syntax.

I stumbled upon the following issue when testing:

```
uv run jj-pre-push --help
Traceback (most recent call last):

  File "/Users/hugoh/Code/jj-pre-push/.venv/bin/jj-pre-push", line 10, in <module>
    sys.exit(app())
             ~~~^^

RuntimeError: Type not yet supported: typing.Literal['default', 'remote-ancestors']

zsh: exit 1     uv run jj-pre-push --help
```

It predated my change, so I'm unsure if it's my setup or an actual bug. If the latter, I have a fix, but I didn't want to bundle it with this change.