### PR TITLE
Re-use the working commit when empty and relevant

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,19 @@ Use `jj-pre-push push` (or an alias - personally I use `jj push`) as a replaceme
 1. Determines which bookmarks the corresponding `jj git push` will update on the remote,
    and how they would change.
 2. For each of these bookmarks in turn:
-   - Checks out the bookmark to the working copy
+   - Checks out the bookmark to the working copy (or uses the existing working commit
+     if it is empty and based on the bookmark).
    - Runs the pre-push hooks defined in your .pre-commit-config.yaml on the same set of
      files pre-commit would when pushing the same change. (For existing branches that's
      the files touched in the range `old`...`new`; for new branches it's the files
      touched in all ancestors of `new` that aren't present on the remote.)
    - Reports any failures; and if any files were modified reports the change ID(s) in which
      these modifications can be found.
+
+   > **Note:** If your current working commit is empty and is a direct child of the
+   > bookmark being checked, `jj-pre-push` will run the checks directly in that
+   > working commit instead of creating a new one. Any modifications made by the hooks
+   > will be preserved in your working commit, ready to be diffed or squashed.
 3. If all hooks succeeded on all branches, executes `jj git push` with the arguments
    provided; otherwise nothing is pushed.
 4. Returns the working copy to its original change.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Use `jj-pre-push push` (or an alias - personally I use `jj push`) as a replaceme
    - Reports any failures; and if any files were modified reports the change ID(s) in which
      these modifications can be found.
 
-   > **Note:** If your current working commit is empty and is a direct child of the
+   > [!NOTE]
+   > If your current working commit is empty and is a direct child of the
    > bookmark being checked, `jj-pre-push` will run the checks directly in that
    > working commit instead of creating a new one. Any modifications made by the hooks
    > will be preserved in your working commit, ready to be diffed or squashed.

--- a/src/jj_pre_push/cli.py
+++ b/src/jj_pre_push/cli.py
@@ -137,9 +137,7 @@ def check(ctx: typer.Context):
             # branch is a merge of two local branches started from distinct remote
             # branches. In this rare case we run once per root. Would be more efficient
             # to union the lists of changed files I guess?
-            use_orig_wc = (
-                orig_wc.empty and u.new_commit in orig_parent_ids and len(from_refs) == 1
-            )
+            use_orig_wc = orig_wc.empty and u.new_commit in orig_parent_ids and len(from_refs) == 1
             for from_ref in from_refs:
                 if use_orig_wc:
                     logger.info(

--- a/src/jj_pre_push/cli.py
+++ b/src/jj_pre_push/cli.py
@@ -105,6 +105,15 @@ def check(ctx: typer.Context):
         return
 
     success = True
+
+    # Optimization: if the current working commit is empty and is based on the
+    # bookmark being pushed, we can run the checker directly in that working
+    # commit instead of creating a new one. This leaves any edits made by the
+    # checker in the working commit, ready for the user.
+    orig_wc = jj.current_change()
+    orig_parents = jj.get_changes("parents(@)")
+    orig_parent_ids = [c.commit_id for c in orig_parents]
+
     with jj.autostash():
         for u in updates:
             assert u.new_commit is not None
@@ -128,8 +137,18 @@ def check(ctx: typer.Context):
             # branch is a merge of two local branches started from distinct remote
             # branches. In this rare case we run once per root. Would be more efficient
             # to union the lists of changed files I guess?
+            use_orig_wc = (
+                orig_wc.empty and u.new_commit in orig_parent_ids and len(from_refs) == 1
+            )
             for from_ref in from_refs:
-                jj.new(u.new_commit)
+                if use_orig_wc:
+                    logger.info(
+                        f"Using empty working commit {orig_wc.change_id} on top of {u.new_commit}"
+                    )
+                    jj.edit(orig_wc.change_id)
+                else:
+                    jj.new(u.new_commit)
+
                 logger.info(f"Running {settings.checker} on {from_ref}...{u.new_commit}")
                 # Even though pre-commit is python, we call it as a subprocess so that
                 # we use whatever version the user has installed on their PATH - seems

--- a/src/jj_pre_push/cli.py
+++ b/src/jj_pre_push/cli.py
@@ -106,7 +106,7 @@ def check(ctx: typer.Context):
 
     success = True
 
-    # Optimization: if the current working commit is empty and is based on the
+    # QOL: if the current working commit is empty and is based on the
     # bookmark being pushed, we can run the checker directly in that working
     # commit instead of creating a new one. This leaves any edits made by the
     # checker in the working commit, ready for the user.

--- a/src/jj_pre_push/jj.py
+++ b/src/jj_pre_push/jj.py
@@ -80,14 +80,23 @@ def new(ref: str | None = None):
     jj(cmd)
 
 
+def edit(ref: str):
+    jj(["edit", ref, "--quiet"])
+
+
 @contextmanager
 def autostash():
     """Remember the working copy commit and return to it at the end of the context."""
+    orig_wc = current_change()
     # Create a temporary bookmark so the current change isn't automatically abandoned
     tempbm = "jj-pre-push-keep-" + "".join(random.choices(string.ascii_letters, k=10))
     jj(["bookmark", "create", tempbm, "-r", "@", "--quiet"])
     try:
         yield
     finally:
-        jj(["edit", tempbm, "--quiet"])
+        # Restore by change_id rather than the temp bookmark. This ensures that if
+        # the working commit was updated (e.g. by a checker making edits) during
+        # the block, we return to the updated version rather than resetting to the
+        # state before the block.
+        jj(["edit", orig_wc.change_id, "--quiet"])
         jj(["bookmark", "forget", tempbm, "--quiet"])

--- a/src/jj_pre_push/jj.py
+++ b/src/jj_pre_push/jj.py
@@ -98,5 +98,6 @@ def autostash():
         # the working commit was updated (e.g. by a checker making edits) during
         # the block, we return to the updated version rather than resetting to the
         # state before the block.
+        # We still need tempbm to avoid the change being abandoned in other circumstances.
         jj(["edit", orig_wc.change_id, "--quiet"])
         jj(["bookmark", "forget", tempbm, "--quiet"])


### PR DESCRIPTION
This allows an important common case of running the pre-commit checks after having advancade a bookmark to not require tracking down and editting a new commit for any changes and instead making them in the working commit when it is clean. When it isn't clean, a new commit is still used to avoid any destructive operation here.

Assisted-by: Antigravity with Gemini