### PR TITLE
allow prek.toml as valid configuration

### DIFF
--- a/src/jj_pre_push/cli.py
+++ b/src/jj_pre_push/cli.py
@@ -83,7 +83,10 @@ def check(ctx: typer.Context):
             logger.error(e.message)
         raise typer.Exit(e.returncode)
 
-    if not (root / ".pre-commit-config.yaml").exists():
+    config_files = [root / ".pre-commit-config.yaml", root / ".pre-commit-config.yml"]
+    if settings.checker == "prek":
+        config_files.append(root / "prek.toml")
+    if not any(cf.exists() for cf in config_files):
         logger.info("No pre-commit config in this repo, nothing to check.")
         return
 

--- a/src/jj_pre_push/cli.py
+++ b/src/jj_pre_push/cli.py
@@ -83,9 +83,9 @@ def check(ctx: typer.Context):
             logger.error(e.message)
         raise typer.Exit(e.returncode)
 
-    config_files = [root / ".pre-commit-config.yaml", root / ".pre-commit-config.yml"]
+    config_files = [root / ".pre-commit-config.yaml"]
     if settings.checker == "prek":
-        config_files.append(root / "prek.toml")
+        config_files.extend((root / "prek.toml", root / ".pre-commit-config.yml"))
     if not any(cf.exists() for cf in config_files):
         logger.info("No pre-commit config in this repo, nothing to check.")
         return


### PR DESCRIPTION
This PR adds support for `.pre-commit-config.yml` and `prek.toml` as valid configuration files, the latter only if the `checker` is set to `prek`. I'm not sure what version of prek adds support for the TOML configuration, but here's the docs: https://prek.j178.dev/configuration/

I believe prek also supports configuration in subdirectories, but that seems like an advanced use case that I didn't want to cover here.